### PR TITLE
fix: eslint dependency problems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [10, 11, 12, 13, 14]
+        node-version: [12, 13, 14, 16, 17, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/package.json
+++ b/package.json
@@ -48,23 +48,28 @@
         "watch": "rollup -c -w"
     },
     "dependencies": {
-        "yonius": "^0.4.2"
+        "yonius": "^0.11.7"
     },
     "devDependencies": {
-        "@babel/core": "^7.10.2",
-        "@babel/preset-env": "^7.10.2",
-        "@rollup/plugin-babel": "^5.0.2",
-        "@rollup/plugin-commonjs": "^12.0.0",
-        "@rollup/plugin-node-resolve": "^8.0.0",
-        "eslint": "^7.1.0",
-        "eslint-config-hive": "^0.3.3",
-        "mocha": "^7.2.0",
+        "@babel/core": "^7.18.2",
+        "@babel/preset-env": "^7.18.2",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-commonjs": "^22.0.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "eslint": "^8.16.0",
+        "eslint-config-hive": "^0.5.8",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-mocha": ">=10.0.0 && <10.0.3",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "mocha": "^9.2.2",
         "mocha-cli": "^1.0.1",
-        "npm-check-updates": "^6.0.1",
-        "prettier": "^2.0.5",
+        "npm-check-updates": "^13.0.3",
+        "prettier": "^2.6.2",
         "prettier-config-hive": "^0.1.7",
-        "rollup": "^2.13.0",
+        "rollup": "^2.74.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "sort-package-json": "^1.44.0"
+        "sort-package-json": "^1.57.0"
     }
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Similar to https://github.com/ripe-tech/ripe-components-vue/pull/596 |
| Dependencies | |
| Decisions | - Port `eslint-config-hive` dependencies<br>- Lock `eslint-plugin-mocha` to `10.0.3` due to problem with mocha and ramda packages |
| Animated GIF | -- |

